### PR TITLE
Fix README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ And then execute:
 
 To import all assets in your Rails project, add the following line to your application.scss:
 ``` ruby
-@import "bulma";
+ *= require bulma
 ```
 
 For information about customizing Bulma,


### PR DESCRIPTION
The instructions to import the library were wrong.
In a clean machine, using your gem as described, I would get a lot of errors because it couldn't be found.
Importing libraries with `@import "library-name";` works for libraries installed with npm/yarn, so I'm guessing you have the library installed that way in your machine, otherwise you would have noticed.
After changing that one line, everything started working as expected.