### PR TITLE
Remove dependency on sass to make it work with sassc

### DIFF
--- a/bulma-rails.gemspec
+++ b/bulma-rails.gemspec
@@ -12,6 +12,4 @@ Gem::Specification.new do |gem|
   gem.files         = `git ls-files`.split($\)
   gem.require_paths = ["lib"]
   gem.license       = 'MIT'
-
-  gem.add_runtime_dependency 'sass', '~> 3.5'
 end


### PR DESCRIPTION
https://github.com/sass/ruby-sass is currently deprecated in favor of sassc (faster version of sass)
