### PR TITLE
Update to Bulma 0.9.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A modern CSS framework based on Flexbox.
 
 Add this line to your application's Gemfile:
 
-    gem "bulma-rails", "~> 0.9.2"
+    gem "bulma-rails", "~> 0.9.3"
 
 And then execute:
 

--- a/app/assets/stylesheets/bulma.sass
+++ b/app/assets/stylesheets/bulma.sass
@@ -1,5 +1,5 @@
 @charset "utf-8"
-/*! bulma.io v0.9.2 | MIT License | github.com/jgthms/bulma */
+/*! bulma.io v0.9.3 | MIT License | github.com/jgthms/bulma */
 @import "sass/utilities/_all"
 @import "sass/base/_all"
 @import "sass/elements/_all"

--- a/app/assets/stylesheets/sass/components/card.sass
+++ b/app/assets/stylesheets/sass/components/card.sass
@@ -2,7 +2,7 @@
 
 $card-color: $text !default
 $card-background-color: $scheme-main !default
-$card-shadow: 0 0.5em 1em -0.125em rgba($scheme-invert, 0.1), 0 0px 0 1px rgba($scheme-invert, 0.02) !default
+$card-shadow: $shadow !default
 $card-radius: 0.25rem !default
 
 $card-header-background-color: transparent !default
@@ -54,6 +54,7 @@ $card-media-margin: $block-spacing !default
     justify-content: center
 
 .card-header-icon
+  +reset
   align-items: center
   cursor: pointer
   display: flex

--- a/app/assets/stylesheets/sass/components/dropdown.sass
+++ b/app/assets/stylesheets/sass/components/dropdown.sass
@@ -8,7 +8,7 @@ $dropdown-content-offset: 4px !default
 $dropdown-content-padding-bottom: 0.5rem !default
 $dropdown-content-padding-top: 0.5rem !default
 $dropdown-content-radius: $radius !default
-$dropdown-content-shadow: 0 0.5em 1em -0.125em rgba($scheme-invert, 0.1), 0 0px 0 1px rgba($scheme-invert, 0.02) !default
+$dropdown-content-shadow: $shadow !default
 $dropdown-content-z: 20 !default
 
 $dropdown-item-color: $text !default

--- a/app/assets/stylesheets/sass/components/level.sass
+++ b/app/assets/stylesheets/sass/components/level.sass
@@ -1,6 +1,6 @@
 @import "../utilities/mixins"
 
-$level-item-spacing: ($block-spacing / 2) !default
+$level-item-spacing: ($block-spacing * 0.5) !default
 
 .level
   @extend %block

--- a/app/assets/stylesheets/sass/components/navbar.sass
+++ b/app/assets/stylesheets/sass/components/navbar.sass
@@ -153,6 +153,7 @@ body
   overflow-y: hidden
 
 .navbar-burger
+  @extend %reset
   color: $navbar-burger-color
   +hamburger($navbar-height)
   +ltr-property("margin", auto, false)

--- a/app/assets/stylesheets/sass/components/pagination.sass
+++ b/app/assets/stylesheets/sass/components/pagination.sass
@@ -134,12 +134,20 @@ $pagination-shadow-inset: inset 0 1px 2px rgba($scheme-invert, 0.2) !default
     flex-shrink: 1
     justify-content: flex-start
     order: 1
+  .pagination-previous,
+  .pagination-next,
+  .pagination-link,
+  .pagination-ellipsis
+    margin-bottom: 0
+    margin-top: 0
   .pagination-previous
     order: 2
   .pagination-next
     order: 3
   .pagination
     justify-content: space-between
+    margin-bottom: 0
+    margin-top: 0
     &.is-centered
       .pagination-previous
         order: 1

--- a/app/assets/stylesheets/sass/components/panel.sass
+++ b/app/assets/stylesheets/sass/components/panel.sass
@@ -3,7 +3,7 @@
 $panel-margin: $block-spacing !default
 $panel-item-border: 1px solid $border-light !default
 $panel-radius: $radius-large !default
-$panel-shadow: 0 0.5em 1em -0.125em rgba($scheme-invert, 0.1), 0 0px 0 1px rgba($scheme-invert, 0.02) !default
+$panel-shadow: $shadow !default
 
 $panel-heading-background-color: $border-light !default
 $panel-heading-color: $text-strong !default

--- a/app/assets/stylesheets/sass/elements/box.sass
+++ b/app/assets/stylesheets/sass/elements/box.sass
@@ -3,7 +3,7 @@
 $box-color: $text !default
 $box-background-color: $scheme-main !default
 $box-radius: $radius-large !default
-$box-shadow: 0 0.5em 1em -0.125em rgba($scheme-invert, 0.1), 0 0px 0 1px rgba($scheme-invert, 0.02) !default
+$box-shadow: $shadow !default
 $box-padding: 1.25rem !default
 
 $box-link-hover-shadow: 0 0.5em 1em -0.125em rgba($scheme-invert, 0.1), 0 0 0 1px $link !default

--- a/app/assets/stylesheets/sass/elements/button.sass
+++ b/app/assets/stylesheets/sass/elements/button.sass
@@ -84,14 +84,14 @@ $button-colors: $colors !default
       height: 1.5em
       width: 1.5em
     &:first-child:not(:last-child)
-      +ltr-property("margin", calc(#{-1 / 2 * $button-padding-horizontal} - #{$button-border-width}), false)
-      +ltr-property("margin", $button-padding-horizontal / 4)
+      +ltr-property("margin", calc(#{-0.5 * $button-padding-horizontal} - #{$button-border-width}), false)
+      +ltr-property("margin", $button-padding-horizontal * 0.25)
     &:last-child:not(:first-child)
-      +ltr-property("margin", $button-padding-horizontal / 4, false)
-      +ltr-property("margin", calc(#{-1 / 2 * $button-padding-horizontal} - #{$button-border-width}))
+      +ltr-property("margin", $button-padding-horizontal * 0.25, false)
+      +ltr-property("margin", calc(#{-0.5 * $button-padding-horizontal} - #{$button-border-width}))
     &:first-child:last-child
-      margin-left: calc(#{-1 / 2 * $button-padding-horizontal} - #{$button-border-width})
-      margin-right: calc(#{-1 / 2 * $button-padding-horizontal} - #{$button-border-width})
+      margin-left: calc(#{-0.5 * $button-padding-horizontal} - #{$button-border-width})
+      margin-right: calc(#{-0.5 * $button-padding-horizontal} - #{$button-border-width})
   // States
   &:hover,
   &.is-hovered

--- a/app/assets/stylesheets/sass/elements/content.sass
+++ b/app/assets/stylesheets/sass/elements/content.sass
@@ -151,6 +151,8 @@ $content-table-foot-cell-color: $text-strong !default
   // Sizes
   &.is-small
     font-size: $size-small
+  &.is-normal
+    font-size: $size-normal
   &.is-medium
     font-size: $size-medium
   &.is-large

--- a/app/assets/stylesheets/sass/elements/icon.sass
+++ b/app/assets/stylesheets/sass/elements/icon.sass
@@ -32,9 +32,15 @@ $icon-text-spacing: 0.25em !default
     flex-grow: 0
     flex-shrink: 0
     &:not(:last-child)
-      margin-right: $icon-text-spacing
+      +ltr
+        margin-right: $icon-text-spacing
+      +rtl
+        margin-left: $icon-text-spacing
     &:not(:first-child)
-      margin-left: $icon-text-spacing
+      +ltr
+        margin-left: $icon-text-spacing
+      +rtl
+        margin-right: $icon-text-spacing
 
 div.icon-text
   display: flex

--- a/app/assets/stylesheets/sass/elements/other.sass
+++ b/app/assets/stylesheets/sass/elements/other.sass
@@ -13,16 +13,6 @@
   margin-bottom: 5px
   text-transform: uppercase
 
-.highlight
-  @extend %block
-  font-weight: $weight-normal
-  max-width: 100%
-  overflow: hidden
-  padding: 0
-  pre
-    overflow: auto
-    max-width: 100%
-
 .loader
   @extend %loader
 

--- a/app/assets/stylesheets/sass/elements/title.sass
+++ b/app/assets/stylesheets/sass/elements/title.sass
@@ -43,8 +43,6 @@ $subtitle-negative-margin: -1.25rem !default
   strong
     color: $title-strong-color
     font-weight: $title-strong-weight
-  & + .highlight
-    margin-top: -0.75rem
   &:not(.is-spaced) + .subtitle
     margin-top: $subtitle-negative-margin
   // Sizes

--- a/app/assets/stylesheets/sass/form/file.sass
+++ b/app/assets/stylesheets/sass/form/file.sass
@@ -49,6 +49,8 @@ $file-colors: $form-colors !default
   // Sizes
   &.is-small
     font-size: $size-small
+  &.is-normal
+    font-size: $size-normal
   &.is-medium
     font-size: $size-medium
     .file-icon

--- a/app/assets/stylesheets/sass/grid/columns.sass
+++ b/app/assets/stylesheets/sass/grid/columns.sass
@@ -62,9 +62,9 @@ $column-gap: 0.75rem !default
   @for $i from 0 through 12
     .columns.is-mobile > &.is-#{$i}
       flex: none
-      width: percentage($i / 12)
+      width: percentage(divide($i, 12))
     .columns.is-mobile > &.is-offset-#{$i}
-      +ltr-property("margin", percentage($i / 12), false)
+      +ltr-property("margin", percentage(divide($i, 12)), false)
   +mobile
     &.is-narrow-mobile
       flex: none
@@ -120,9 +120,9 @@ $column-gap: 0.75rem !default
     @for $i from 0 through 12
       &.is-#{$i}-mobile
         flex: none
-        width: percentage($i / 12)
+        width: percentage(divide($i, 12))
       &.is-offset-#{$i}-mobile
-        +ltr-property("margin", percentage($i / 12), false)
+        +ltr-property("margin", percentage(divide($i, 12)), false)
   +tablet
     &.is-narrow,
     &.is-narrow-tablet
@@ -199,10 +199,10 @@ $column-gap: 0.75rem !default
       &.is-#{$i},
       &.is-#{$i}-tablet
         flex: none
-        width: percentage($i / 12)
+        width: percentage(divide($i, 12))
       &.is-offset-#{$i},
       &.is-offset-#{$i}-tablet
-        +ltr-property("margin", percentage($i / 12), false)
+        +ltr-property("margin", percentage(divide($i, 12)), false)
   +touch
     &.is-narrow-touch
       flex: none
@@ -258,9 +258,9 @@ $column-gap: 0.75rem !default
     @for $i from 0 through 12
       &.is-#{$i}-touch
         flex: none
-        width: percentage($i / 12)
+        width: percentage(divide($i, 12))
       &.is-offset-#{$i}-touch
-        +ltr-property("margin", percentage($i / 12), false)
+        +ltr-property("margin", percentage(divide($i, 12)), false)
   +desktop
     &.is-narrow-desktop
       flex: none
@@ -316,9 +316,9 @@ $column-gap: 0.75rem !default
     @for $i from 0 through 12
       &.is-#{$i}-desktop
         flex: none
-        width: percentage($i / 12)
+        width: percentage(divide($i, 12))
       &.is-offset-#{$i}-desktop
-        +ltr-property("margin", percentage($i / 12), false)
+        +ltr-property("margin", percentage(divide($i, 12)), false)
   +widescreen
     &.is-narrow-widescreen
       flex: none
@@ -374,9 +374,9 @@ $column-gap: 0.75rem !default
     @for $i from 0 through 12
       &.is-#{$i}-widescreen
         flex: none
-        width: percentage($i / 12)
+        width: percentage(divide($i, 12))
       &.is-offset-#{$i}-widescreen
-        +ltr-property("margin", percentage($i / 12), false)
+        +ltr-property("margin", percentage(divide($i, 12)), false)
   +fullhd
     &.is-narrow-fullhd
       flex: none
@@ -432,9 +432,9 @@ $column-gap: 0.75rem !default
     @for $i from 0 through 12
       &.is-#{$i}-fullhd
         flex: none
-        width: percentage($i / 12)
+        width: percentage(divide($i, 12))
       &.is-offset-#{$i}-fullhd
-        +ltr-property("margin", percentage($i / 12), false)
+        +ltr-property("margin", percentage(divide($i, 12)), false)
 
 .columns
   +ltr-property("margin", (-$column-gap), false)

--- a/app/assets/stylesheets/sass/grid/tiles.sass
+++ b/app/assets/stylesheets/sass/grid/tiles.sass
@@ -33,4 +33,4 @@ $tile-spacing: 0.75rem !default
     @for $i from 1 through 12
       &.is-#{$i}
         flex: none
-        width: ($i / 12) * 100%
+        width: (divide($i, 12)) * 100%

--- a/app/assets/stylesheets/sass/helpers/spacing.sass
+++ b/app/assets/stylesheets/sass/helpers/spacing.sass
@@ -8,7 +8,7 @@ $spacing-shortcuts: ("margin": "m", "padding": "p") !default
 $spacing-directions: ("top": "t", "right": "r", "bottom": "b", "left": "l") !default
 $spacing-horizontal: "x" !default
 $spacing-vertical: "y" !default
-$spacing-values: ("0": 0, "1": 0.25rem, "2": 0.5rem, "3": 0.75rem, "4": 1rem, "5": 1.5rem, "6": 3rem) !default
+$spacing-values: ("0": 0, "1": 0.25rem, "2": 0.5rem, "3": 0.75rem, "4": 1rem, "5": 1.5rem, "6": 3rem, "auto": auto) !default
 
 @each $property, $shortcut in $spacing-shortcuts
   @each $name, $value in $spacing-values

--- a/app/assets/stylesheets/sass/helpers/typography.sass
+++ b/app/assets/stylesheets/sass/helpers/typography.sass
@@ -72,6 +72,9 @@ $alignments: ('centered': 'center', 'justified': 'justify', 'left': 'left', 'rig
 
 .is-italic
   font-style: italic !important
+  
+.is-underlined
+  text-decoration: underline !important
 
 .has-text-weight-light
   font-weight: $weight-light !important

--- a/app/assets/stylesheets/sass/layout/hero.sass
+++ b/app/assets/stylesheets/sass/layout/hero.sass
@@ -1,9 +1,10 @@
 @import "../utilities/mixins"
 
 $hero-body-padding: 3rem 1.5rem !default
+$hero-body-padding-tablet: 3rem 3rem !default
 $hero-body-padding-small: 1.5rem !default
-$hero-body-padding-medium: 9rem 1.5rem !default
-$hero-body-padding-large: 18rem 1.5rem !default
+$hero-body-padding-medium: 9rem 4.5rem !default
+$hero-body-padding-large: 18rem 6rem !default
 
 $hero-colors: $colors !default
 
@@ -55,6 +56,7 @@ $hero-colors: $colors !default
             opacity: 1
         li
           &.is-active a
+            color: $color !important
             opacity: 1
         &.is-boxed,
         &.is-toggle
@@ -147,3 +149,5 @@ $hero-colors: $colors !default
   flex-grow: 1
   flex-shrink: 0
   padding: $hero-body-padding
+  +tablet
+    padding: $hero-body-padding-tablet

--- a/app/assets/stylesheets/sass/layout/section.sass
+++ b/app/assets/stylesheets/sass/layout/section.sass
@@ -1,13 +1,15 @@
 @import "../utilities/mixins"
 
 $section-padding: 3rem 1.5rem !default
-$section-padding-medium: 9rem 1.5rem !default
-$section-padding-large: 18rem 1.5rem !default
+$section-padding-desktop: 3rem 3rem !default
+$section-padding-medium: 9rem 4.5rem !default
+$section-padding-large: 18rem 6rem !default
 
 .section
   padding: $section-padding
   // Responsiveness
   +desktop
+    padding: $section-padding-desktop
     // Sizes
     &.is-medium
       padding: $section-padding-medium

--- a/app/assets/stylesheets/sass/utilities/derived-variables.sass
+++ b/app/assets/stylesheets/sass/utilities/derived-variables.sass
@@ -99,6 +99,10 @@ $size-normal: $size-6 !default
 $size-medium: $size-5 !default
 $size-large: $size-4 !default
 
+// Effects
+
+$shadow: 0 0.5em 1em -0.125em rgba($scheme-invert, 0.1), 0 0px 0 1px rgba($scheme-invert, 0.02) !default
+
 // Lists and maps
 $custom-colors: null !default
 $custom-shades: null !default

--- a/app/assets/stylesheets/sass/utilities/extends.sass
+++ b/app/assets/stylesheets/sass/utilities/extends.sass
@@ -20,3 +20,6 @@
 
 %overlay
   +overlay
+
+%reset
+  +reset

--- a/app/assets/stylesheets/sass/utilities/functions.sass
+++ b/app/assets/stylesheets/sass/utilities/functions.sass
@@ -58,7 +58,7 @@
       $value: $value * $number
   @else if $exp < 0
     @for $i from 1 through -$exp
-      $value: $value / $number
+      $value: divide($value, $number)
   @return $value
 
 @function colorLuminance($color)
@@ -67,11 +67,11 @@
   $color-rgb: ('red': red($color),'green': green($color),'blue': blue($color))
   @each $name, $value in $color-rgb
     $adjusted: 0
-    $value: $value / 255
+    $value: divide($value, 255)
     @if $value < 0.03928
-      $value: $value / 12.92
+      $value: divide($value, 12.92)
     @else
-      $value: ($value + .055) / 1.055
+      $value: divide(($value + .055), 1.055)
       $value: powerNumber($value, 2)
     $color-rgb: map-merge($color-rgb, ($name: $value))
   @return (map-get($color-rgb, 'red') * .2126) + (map-get($color-rgb, 'green') * .7152) + (map-get($color-rgb, 'blue') * .0722)
@@ -113,3 +113,24 @@
   @if type-of($color) != 'color'
     @return $color
   @return lighten($color, $amount)
+
+// Custom divide function by @mdo from https://github.com/twbs/bootstrap/pull/34245
+// Replaces old slash division deprecated in Dart Sass
+@function divide($dividend, $divisor, $precision: 10)
+  $sign: if($dividend > 0 and $divisor > 0, 1, -1)
+  $dividend: abs($dividend)
+  $divisor: abs($divisor)
+  $quotient: 0
+  $remainder: $dividend
+  @if $dividend == 0
+    @return 0
+  @if $divisor == 0
+    @error "Cannot divide by 0"
+  @if $divisor == 1
+    @return $dividend
+  @while $remainder >= $divisor
+    $quotient: $quotient + 1
+    $remainder: $remainder - $divisor
+  @if $remainder > 0 and $precision > 0
+    $remainder: divide($remainder * 10, $divisor, $precision - 1) * .1
+  @return ($quotient + $remainder) * $sign

--- a/app/assets/stylesheets/sass/utilities/initial-variables.sass
+++ b/app/assets/stylesheets/sass/utilities/initial-variables.sass
@@ -16,11 +16,11 @@ $white-bis:    hsl(0, 0%, 98%) !default
 $white:        hsl(0, 0%, 100%) !default
 
 $orange:       hsl(14,  100%, 53%) !default
-$yellow:       hsl(48,  100%, 67%) !default
-$green:        hsl(141, 53%,  53%) !default
+$yellow:       hsl(44,  100%, 77%) !default
+$green:        hsl(153, 53%,  53%) !default
 $turquoise:    hsl(171, 100%, 41%) !default
-$cyan:         hsl(204, 71%,  53%) !default
-$blue:         hsl(217, 71%,  53%) !default
+$cyan:         hsl(207, 61%,  53%) !default
+$blue:         hsl(229, 53%,  53%) !default
 $purple:       hsl(271, 100%, 71%) !default
 $red:          hsl(348, 86%, 61%) !default
 
@@ -69,7 +69,7 @@ $easing: ease-out !default
 $radius-small: 2px !default
 $radius: 4px !default
 $radius-large: 6px !default
-$radius-rounded: 290486px !default
+$radius-rounded: 9999px !default
 $speed: 86ms !default
 
 // Flags

--- a/app/assets/stylesheets/sass/utilities/mixins.sass
+++ b/app/assets/stylesheets/sass/utilities/mixins.sass
@@ -9,11 +9,11 @@
 =center($width, $height: 0)
   position: absolute
   @if $height != 0
-    left: calc(50% - (#{$width} / 2))
-    top: calc(50% - (#{$height} / 2))
+    left: calc(50% - (#{$width} * 0.5))
+    top: calc(50% - (#{$height} * 0.5))
   @else
-    left: calc(50% - (#{$width} / 2))
-    top: calc(50% - (#{$width} / 2))
+    left: calc(50% - (#{$width} * 0.5))
+    top: calc(50% - (#{$width} * 0.5))
 
 =fa($size, $dimensions)
   display: inline-block
@@ -67,6 +67,18 @@
   @each $placeholder in $placeholders
     &:#{$placeholder}-placeholder
       @content
+
+=reset
+  -moz-appearance: none
+  -webkit-appearance: none
+  appearance: none
+  background: none
+  border: none
+  color: currentColor
+  font-family: inherit
+  font-size: 1em
+  margin: 0
+  padding: 0
 
 // Responsiveness
 

--- a/bulma-rails.gemspec
+++ b/bulma-rails.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |gem|
   gem.name          = 'bulma-rails'
-  gem.version       = '0.9.2'
+  gem.version       = '0.9.3'
   gem.authors       = ["Joshua Jansen"]
   gem.email         = ["joshuajansen88@gmail.com"]
   gem.description   = %q{A modern CSS framework based on Flexbox}


### PR DESCRIPTION
### Description
This PR upgrades the gem to use the newest version of Bulma. The diff between the two versions can be seen [here](https://github.com/jgthms/bulma/compare/0.9.2...0.9.3), and the release notes are available [here](https://github.com/jgthms/bulma/releases/tag/0.9.3). I used the official download from the [Bulma releases page](https://github.com/jgthms/bulma/releases/download/0.9.3/bulma-0.9.3.zip) for these file changes.