### PR TITLE
Update bulma to 0.9.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A modern CSS framework based on Flexbox.
 
 Add this line to your application's Gemfile:
 
-    gem "bulma-rails", "~> 0.9.3"
+    gem "bulma-rails", "~> 0.9.4"
 
 And then execute:
 

--- a/app/assets/stylesheets/bulma.sass
+++ b/app/assets/stylesheets/bulma.sass
@@ -1,5 +1,5 @@
 @charset "utf-8"
-/*! bulma.io v0.9.3 | MIT License | github.com/jgthms/bulma */
+/*! bulma.io v0.9.4 | MIT License | github.com/jgthms/bulma */
 @import "sass/utilities/_all"
 @import "sass/base/_all"
 @import "sass/elements/_all"

--- a/app/assets/stylesheets/sass/components/pagination.sass
+++ b/app/assets/stylesheets/sass/components/pagination.sass
@@ -88,7 +88,8 @@ $pagination-shadow-inset: inset 0 1px 2px rgba($scheme-invert, 0.2) !default
     border-color: $pagination-focus-border-color
   &:active
     box-shadow: $pagination-shadow-inset
-  &[disabled]
+  &[disabled],
+  &.is-disabled
     background-color: $pagination-disabled-background-color
     border-color: $pagination-disabled-border-color
     box-shadow: none

--- a/app/assets/stylesheets/sass/elements/button.sass
+++ b/app/assets/stylesheets/sass/elements/button.sass
@@ -44,6 +44,7 @@ $button-static-background-color: $scheme-main-ter !default
 $button-static-border-color: $border !default
 
 $button-colors: $colors !default
+$button-responsive-sizes: ("mobile": ("small": ($size-small * 0.75), "normal": ($size-small * 0.875), "medium": $size-small, "large": $size-normal), "tablet-only": ("small": ($size-small * 0.875), "normal": ($size-small), "medium": $size-normal, "large": $size-medium)) !default
 
 // The button sizes use mixins so they can be used at different breakpoints
 =button-small
@@ -163,7 +164,7 @@ $button-colors: $colors !default
       &[disabled],
       fieldset[disabled] &
         background-color: $color
-        border-color: transparent
+        border-color: $color
         box-shadow: none
       &.is-inverted
         background-color: $color-invert
@@ -343,3 +344,14 @@ $button-colors: $colors !default
       .button:not(.is-fullwidth)
         margin-left: 0.25rem
         margin-right: 0.25rem
+
+@each $bp-name, $bp-sizes in $button-responsive-sizes
+  +breakpoint($bp-name)
+    @each $size, $value in $bp-sizes
+      @if $size != "normal"
+        .button.is-responsive.is-#{$size}
+          font-size: $value
+      @else
+        .button.is-responsive,
+        .button.is-responsive.is-normal
+          font-size: $value

--- a/app/assets/stylesheets/sass/elements/content.sass
+++ b/app/assets/stylesheets/sass/elements/content.sass
@@ -4,6 +4,8 @@ $content-heading-color: $text-strong !default
 $content-heading-weight: $weight-semibold !default
 $content-heading-line-height: 1.125 !default
 
+$content-block-margin-bottom: 1em !default
+
 $content-blockquote-background-color: $background !default
 $content-blockquote-border-left: 5px solid $border !default
 $content-blockquote-padding: 1.25em 1.5em !default
@@ -16,6 +18,7 @@ $content-table-cell-padding: 0.5em 0.75em !default
 $content-table-cell-heading-color: $text-strong !default
 $content-table-head-cell-border-width: 0 0 2px !default
 $content-table-head-cell-color: $text-strong !default
+$content-table-body-last-row-cell-border-bottom-width: 0 !default
 $content-table-foot-cell-border-width: 2px 0 0 !default
 $content-table-foot-cell-color: $text-strong !default
 
@@ -33,7 +36,7 @@ $content-table-foot-cell-color: $text-strong !default
   pre,
   table
     &:not(:last-child)
-      margin-bottom: 1em
+      margin-bottom: $content-block-margin-bottom
   h1,
   h2,
   h3,
@@ -144,7 +147,7 @@ $content-table-foot-cell-color: $text-strong !default
         &:last-child
           td,
           th
-            border-bottom-width: 0
+            border-bottom-width: $content-table-body-last-row-cell-border-bottom-width
   .tabs
     li + li
       margin-top: 0

--- a/app/assets/stylesheets/sass/elements/table.sass
+++ b/app/assets/stylesheets/sass/elements/table.sass
@@ -7,6 +7,7 @@ $table-cell-border: 1px solid $border !default
 $table-cell-border-width: 0 0 1px !default
 $table-cell-padding: 0.5em 0.75em !default
 $table-cell-heading-color: $text-strong !default
+$table-cell-text-align: left !default
 
 $table-head-cell-border-width: 0 0 2px !default
 $table-head-cell-color: $text-strong !default
@@ -60,7 +61,7 @@ $table-colors: $colors !default
   th
     color: $table-cell-heading-color
     &:not([align])
-      text-align: inherit
+      text-align: $table-cell-text-align
   tr
     &.is-selected
       background-color: $table-row-active-background-color

--- a/app/assets/stylesheets/sass/form/select.sass
+++ b/app/assets/stylesheets/sass/form/select.sass
@@ -66,7 +66,8 @@ $select-colors: $form-colors !default
   // Modifiers
   &.is-disabled
     &::after
-      border-color: $input-disabled-color
+      border-color: $input-disabled-color !important
+      opacity: 0.5
   &.is-fullwidth
     width: 100%
     select

--- a/app/assets/stylesheets/sass/utilities/functions.sass
+++ b/app/assets/stylesheets/sass/utilities/functions.sass
@@ -82,7 +82,7 @@
   @else
     @return #fff
 
-@function findLightColor($color)
+@function findLightColor($color, $l: 96%)
   @if type-of($color) == 'color'
     $l: 96%
     @if lightness($color) > 96%
@@ -90,9 +90,8 @@
     @return change-color($color, $lightness: $l)
   @return $background
 
-@function findDarkColor($color)
+@function findDarkColor($color, $base-l: 29%)
   @if type-of($color) == 'color'
-    $base-l: 29%
     $luminance: colorLuminance($color)
     $luminance-delta: (0.53 - $luminance)
     $target-l: round($base-l + ($luminance-delta * 53))

--- a/app/assets/stylesheets/sass/utilities/initial-variables.sass
+++ b/app/assets/stylesheets/sass/utilities/initial-variables.sass
@@ -62,6 +62,7 @@ $widescreen-enabled: true !default
 // 1344px container + 4rem
 $fullhd: 1344px + (2 * $gap) !default
 $fullhd-enabled: true !default
+$breakpoints: ("mobile": ("until": $tablet), "tablet": ("from": $tablet), "tablet-only": ("from": $tablet, "until": $desktop), "touch": ("from": $desktop), "desktop": ("from": $desktop), "desktop-only": ("from": $desktop, "until": $widescreen), "until-widescreen": ("until": $widescreen), "widescreen": ("from": $widescreen), "widescreen-only": ("from": $widescreen, "until": $fullhd), "until-fullhd": ("until": $fullhd), "fullhd": ("from": $fullhd)) !default
 
 // Miscellaneous
 

--- a/app/assets/stylesheets/sass/utilities/mixins.sass
+++ b/app/assets/stylesheets/sass/utilities/mixins.sass
@@ -25,6 +25,11 @@
   width: $dimensions
 
 =hamburger($dimensions)
+  -moz-appearance: none
+  -webkit-appearance: none
+  appearance: none
+  background: none
+  border: none
   cursor: pointer
   display: block
   height: $dimensions
@@ -90,6 +95,10 @@
   @media screen and (max-width: $device - 1px)
     @content
 
+=between($from, $until)
+  @media screen and (min-width: $from) and (max-width: $until - 1px)
+    @content
+
 =mobile
   @media screen and (max-width: $tablet - 1px)
     @content
@@ -139,6 +148,21 @@
   @if $fullhd-enabled
     @media screen and (min-width: $fullhd)
       @content
+
+=breakpoint($name)
+  $breakpoint: map-get($breakpoints, $name)
+  @if $breakpoint
+    $from: map-get($breakpoint, "from")
+    $until: map-get($breakpoint, "until")
+    @if $from and $until
+      +between($from, $until)
+        @content
+    @else if $from
+      +from($from)
+        @content
+    @else if $until
+      +until($until)
+        @content
 
 =ltr
   @if not $rtl
@@ -277,4 +301,3 @@
   position: absolute
   right: $offset
   top: $offset
-

--- a/bulma-rails.gemspec
+++ b/bulma-rails.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |gem|
   gem.name          = 'bulma-rails'
-  gem.version       = '0.9.3'
+  gem.version       = '0.9.4'
   gem.authors       = ["Joshua Jansen"]
   gem.email         = ["joshuajansen88@gmail.com"]
   gem.description   = %q{A modern CSS framework based on Flexbox}


### PR DESCRIPTION
This PR upgrades the gem to use the newest version of Bulma. The diff between the two versions can be seen [here](https://github.com/jgthms/bulma/compare/0.9.3...0.9.4), and the release notes are available [here](https://github.com/jgthms/bulma/releases/tag/0.9.4). I used the official download from the [Bulma releases page](https://github.com/jgthms/bulma/releases/download/0.9.4/bulma-0.9.4.zip) for these file changes.