### PR TITLE
Change runtime dependency compiler from sassc to dartsass

### DIFF
--- a/bulma-rails.gemspec
+++ b/bulma-rails.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |gem|
   gem.name          = 'bulma-rails'
-  gem.version       = '0.9.4'
+  gem.version       = '0.9.4-dartsass'
   gem.authors       = ["Joshua Jansen"]
   gem.email         = ["joshuajansen88@gmail.com"]
   gem.description   = %q{A modern CSS framework based on Flexbox}
@@ -13,5 +13,5 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.license       = 'MIT'
 
-  gem.add_runtime_dependency 'sassc', '~> 2.0'
+  gem.add_runtime_dependency "dartsass-rails", "~> 0.5.0"
 end


### PR DESCRIPTION
Resolves #58 

Does not add support for `@use "bulma"` as that would appear to require many changes to Bulma's core SASS lib.
Does work with Dartsass builds however