### PR TITLE
Update bulma to `1.0.1`

### DIFF
--- a/app/assets/stylesheets/sass/base/skeleton.scss
+++ b/app/assets/stylesheets/sass/base/skeleton.scss
@@ -112,15 +112,3 @@ textarea.#{iv.$class-prefix}is-skeleton {
     }
   }
 }
-
-.#{iv.$class-prefix}skeleton {
-  background-image: linear-gradient(
-    0deg,
-    transparent 0%,
-    transparent 50%,
-    #f60 50%,
-    #f60 100%
-  );
-  background-position: top left;
-  background-size: 1.5em;
-}

--- a/app/assets/stylesheets/sass/elements/button.scss
+++ b/app/assets/stylesheets/sass/elements/button.scss
@@ -33,6 +33,7 @@ $button-border-width: cv.getVar("control-border-width") !default;
 
 $button-padding-vertical: 0.5em !default;
 $button-padding-horizontal: 1em !default;
+$button-rounded-padding-horizontal-offset: 0.25em !default;
 
 $button-focus-border-color: cv.getVar("link-focus-border") !default;
 $button-focus-box-shadow-size: 0 0 0 0.125em !default;
@@ -533,8 +534,14 @@ $no-palette: ("white", "black", "light", "dark");
 
   &.#{iv.$class-prefix}is-rounded {
     border-radius: cv.getVar("radius-rounded");
-    padding-left: calc(#{cv.getVar("button-padding-horizontal")} + 0.25em);
-    padding-right: calc(#{cv.getVar("button-padding-horizontal")} + 0.25em);
+    padding-left: calc(
+      #{cv.getVar("button-padding-horizontal")} + #{$button-rounded-padding-horizontal-offset} -
+        #{cv.getVar("button-border-width")}
+    );
+    padding-right: calc(
+      #{cv.getVar("button-padding-horizontal")} + #{$button-rounded-padding-horizontal-offset} -
+        #{cv.getVar("button-border-width")}
+    );
   }
 }
 

--- a/app/assets/stylesheets/sass/form/select.scss
+++ b/app/assets/stylesheets/sass/form/select.scss
@@ -84,6 +84,7 @@ $select-colors: shared.$form-colors !default;
           "input-focus-s": #{cv.getVar($name, "", "-s")},
           "input-focus-l": #{cv.getVar($name, "", "-l")},
           "input-border-l": #{cv.getVar($name, "", "-l")},
+          "arrow-color": #{cv.getVar($name)},
         )
       );
     }

--- a/app/assets/stylesheets/sass/form/shared.scss
+++ b/app/assets/stylesheets/sass/form/shared.scss
@@ -58,7 +58,7 @@ $input-radius: cv.getVar("radius") !default;
 .#{iv.$class-prefix}control,
 .#{iv.$class-prefix}input,
 .#{iv.$class-prefix}textarea,
-.#{iv.$class-prefix}select select {
+.#{iv.$class-prefix}select {
   @include cv.register-vars(
     (
       "input-h": #{$input-h},

--- a/app/assets/stylesheets/sass/grid/grid.scss
+++ b/app/assets/stylesheets/sass/grid/grid.scss
@@ -10,7 +10,7 @@ $column-min-base: 1.5rem;
 @mixin fixed-grid-properties($suffix: "") {
   @for $i from 1 through $max-column-count {
     &.#{iv.$class-prefix}has-#{$i}-cols#{$suffix} {
-      .#{iv.$class-prefix}grid {
+      > .#{iv.$class-prefix}grid {
         @include cv.register-var("grid-column-count", #{$i});
       }
     }
@@ -24,7 +24,7 @@ $grid-container-name: bulma-fixed-grid;
   container-name: $grid-container-name;
   container-type: inline-size;
 
-  .#{iv.$class-prefix}grid {
+  > .#{iv.$class-prefix}grid {
     @include cv.register-vars(
       (
         "grid-gap-count": calc(#{cv.getVar("grid-column-count")} - 1),

--- a/app/assets/stylesheets/sass/themes/light.scss
+++ b/app/assets/stylesheets/sass/themes/light.scss
@@ -81,6 +81,7 @@ $scheme-main: hsl(iv.$scheme-h, iv.$scheme-s, $scheme-main-l);
       "radius-rounded": 9999px,
       "speed": 86ms,
 
+      "arrow-color": #{cv.getVar("link")},
       "loading-color": #{cv.getVar("border")},
       "burger-h": #{cv.getVar("link-h")},
       "burger-s": #{cv.getVar("link-s")},

--- a/app/assets/stylesheets/sass/utilities/mixins.scss
+++ b/app/assets/stylesheets/sass/utilities/mixins.scss
@@ -1,7 +1,7 @@
 @use "initial-variables" as iv;
 @use "css-variables" as cv;
 
-@mixin arrow($color: #{cv.getVar("link")}) {
+@mixin arrow($color: #{cv.getVar("arrow-color")}) {
   border: 0.125em solid $color;
   border-right: 0;
   border-top: 0;

--- a/bulma-rails.gemspec
+++ b/bulma-rails.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |gem|
   gem.name          = "bulma-rails"
-  gem.version       = "1.0.0"
+  gem.version       = "1.0.1"
   gem.authors       = ["Joshua Jansen"]
   gem.email         = ["joshuajansen88@gmail.com"]
   gem.description   = %q{A modern CSS framework based on Flexbox}


### PR DESCRIPTION
This PR upgrades the gem to use the newest version of [Bulma 1.0.1](https://github.com/jgthms/bulma/releases/tag/1.0.1). Used the official download from the [Bulma releases page](https://github.com/jgthms/bulma/releases/download/1.0.1/bulma-1.0.1.zip) for these file changes.