### PR TITLE
update Bulma to `1.0.4`

### DIFF
--- a/app/assets/stylesheets/bulma.scss
+++ b/app/assets/stylesheets/bulma.scss
@@ -1,4 +1,4 @@
 @charset "utf-8";
 
-/*! bulma.io v1.0.3 | MIT License | github.com/jgthms/bulma */
+/*! bulma.io v1.0.4 | MIT License | github.com/jgthms/bulma */
 @use "sass";

--- a/app/assets/stylesheets/sass/base/generic.scss
+++ b/app/assets/stylesheets/sass/base/generic.scss
@@ -1,3 +1,4 @@
+@use "../utilities/initial-variables" as iv;
 @use "../utilities/css-variables.scss" as cv;
 @use "../utilities/mixins" as mx;
 
@@ -32,7 +33,7 @@ $pre-font-size: 0.875em !default;
 $pre-padding: 1.25rem 1.5rem !default;
 $pre-code-font-size: 1em !default;
 
-:root {
+#{iv.$variables-host} {
   @include cv.register-vars(
     (
       "body-background-color": #{$body-background-color},

--- a/app/assets/stylesheets/sass/base/skeleton.scss
+++ b/app/assets/stylesheets/sass/base/skeleton.scss
@@ -9,7 +9,7 @@ $skeleton-block-min-height: 4.5em !default;
 $skeleton-lines-gap: 0.75em !default;
 $skeleton-line-height: 0.75em !default;
 
-:root {
+#{iv.$variables-host} {
   @include cv.register-vars(
     (
       "skeleton-background": #{$skeleton-background},

--- a/app/assets/stylesheets/sass/components/navbar.scss
+++ b/app/assets/stylesheets/sass/components/navbar.scss
@@ -101,7 +101,7 @@ $navbar-colors: dv.$colors !default;
   z-index: cv.getVar("navbar-fixed-z");
 }
 
-:root {
+#{iv.$variables-host} {
   @include cv.register-vars(
     (
       "navbar-height": #{$navbar-height},

--- a/app/assets/stylesheets/sass/elements/button.scss
+++ b/app/assets/stylesheets/sass/elements/button.scss
@@ -383,6 +383,12 @@ $no-palette: ("white", "black", "light", "dark");
     @include cv.register-vars(
       (
         "button-border-width": max(1px, 0.0625em),
+        "loading-color":
+        hsl(
+          #{cv.getVar("button-h")},
+          #{cv.getVar("button-s")},
+          #{cv.getVar("button-l")}
+        ),
       )
     );
 

--- a/app/assets/stylesheets/sass/form/tools.scss
+++ b/app/assets/stylesheets/sass/form/tools.scss
@@ -15,7 +15,7 @@ $label-colors: shared.$form-colors !default;
 
 $field-block-spacing: 0.75rem !default;
 
-:root {
+#{iv.$variables-host} {
   @include cv.register-vars(
     (
       "label-color": #{$label-color},

--- a/app/assets/stylesheets/sass/grid/columns.scss
+++ b/app/assets/stylesheets/sass/grid/columns.scss
@@ -7,7 +7,7 @@
 
 $column-gap: 0.75rem !default;
 
-:root {
+#{iv.$variables-host} {
   @include cv.register-vars(
     (
       "column-gap": #{$column-gap},

--- a/app/assets/stylesheets/sass/helpers/typography.scss
+++ b/app/assets/stylesheets/sass/helpers/typography.scss
@@ -149,6 +149,10 @@ $alignments: (
   font-weight: iv.$weight-bold !important;
 }
 
+.#{iv.$class-prefix}#{iv.$helpers-has-prefix}text-weight-extrabold {
+  font-weight: iv.$weight-extrabold !important;
+}
+
 .#{iv.$class-prefix}#{iv.$helpers-prefix}family-primary {
   font-family: dv.$family-primary !important;
 }

--- a/app/assets/stylesheets/sass/layout/hero.scss
+++ b/app/assets/stylesheets/sass/layout/hero.scss
@@ -122,9 +122,9 @@ $hero-colors: dv.$colors !default;
       // Modifiers
       &.#{iv.$class-prefix}is-bold {
         $gradient-top-left: hsl(
-          calc(#{cv.getVar("hero-h")} - $hero-gradient-h-offset),
-          calc(#{cv.getVar("hero-s")} + $hero-gradient-s-offset),
-          calc(#{cv.getVar("hero-background-l")} + $hero-gradient-l-offset)
+          calc(#{cv.getVar("hero-h")} - #{$hero-gradient-h-offset}),
+          calc(#{cv.getVar("hero-s")} + #{$hero-gradient-s-offset}),
+          calc(#{cv.getVar("hero-background-l")} + #{$hero-gradient-l-offset})
         );
         $gradient-middle: hsl(
           #{cv.getVar("hero-h")},
@@ -132,9 +132,9 @@ $hero-colors: dv.$colors !default;
           #{cv.getVar("hero-background-l")}
         );
         $gradient-bottom-right: hsl(
-          calc(#{cv.getVar("hero-h")} + $hero-gradient-h-offset),
-          calc(#{cv.getVar("hero-s")} - $hero-gradient-s-offset),
-          calc(#{cv.getVar("hero-background-l")} - $hero-gradient-l-offset)
+          calc(#{cv.getVar("hero-h")} + #{$hero-gradient-h-offset}),
+          calc(#{cv.getVar("hero-s")} - #{$hero-gradient-s-offset}),
+          calc(#{cv.getVar("hero-background-l")} - #{$hero-gradient-l-offset})
         );
 
         background-image: linear-gradient(

--- a/app/assets/stylesheets/sass/themes/_index.scss
+++ b/app/assets/stylesheets/sass/themes/_index.scss
@@ -1,13 +1,14 @@
 /* Bulma Themes */
 @charset "utf-8";
 
+@use "../utilities/initial-variables" as iv;
 @use "../utilities/css-variables" as cv;
 
 @use "light";
 @use "dark";
 @use "setup";
 
-:root {
+#{iv.$variables-host} {
   @include light.light-theme;
   @include setup.setup-theme;
 }

--- a/app/assets/stylesheets/sass/themes/light.scss
+++ b/app/assets/stylesheets/sass/themes/light.scss
@@ -73,7 +73,7 @@ $scheme-main: hsl(iv.$scheme-h, iv.$scheme-s, $scheme-main-l);
 
       // Other
       "block-spacing": iv.$block-spacing,
-      "duration": 294ms,
+      "duration": iv.$duration,
       "easing": iv.$easing,
       "radius-small": iv.$radius-small,
       "radius": iv.$radius,

--- a/app/assets/stylesheets/sass/utilities/controls.scss
+++ b/app/assets/stylesheets/sass/utilities/controls.scss
@@ -16,7 +16,7 @@ $control-padding-horizontal: calc(0.75em - #{$control-border-width}) !default;
 
 $control-focus-shadow-l: 50% !default;
 
-:root {
+#{iv.$variables-host} {
   @include cv.register-vars(
     (
       "control-radius": #{$control-radius},

--- a/app/assets/stylesheets/sass/utilities/css-variables.scss
+++ b/app/assets/stylesheets/sass/utilities/css-variables.scss
@@ -495,7 +495,7 @@
 
 @mixin system-theme($name) {
   @media (prefers-color-scheme: #{$name}) {
-    :root {
+    #{iv.$variables-host} {
       @content;
     }
   }

--- a/app/assets/stylesheets/sass/utilities/initial-variables.scss
+++ b/app/assets/stylesheets/sass/utilities/initial-variables.scss
@@ -134,6 +134,7 @@ $breakpoints: (
 
 // Miscellaneous
 
+$duration: 294ms !default;
 $easing: ease-out !default;
 $radius-small: 0.25rem !default;
 $radius: 0.375rem !default;
@@ -153,3 +154,4 @@ $class-prefix: "" !default;
 $cssvars-prefix: "bulma-" !default;
 $helpers-prefix: "is-" !default;
 $helpers-has-prefix: "has-" !default;
+$variables-host: ":root" !default;

--- a/bulma-rails.gemspec
+++ b/bulma-rails.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |gem|
   gem.name          = "bulma-rails"
-  gem.version       = "1.0.3"
+  gem.version       = "1.0.4"
   gem.authors       = ["Joshua Jansen"]
   gem.email         = ["joshuajansen88@gmail.com"]
   gem.description   = %q{A modern CSS framework based on Flexbox}


### PR DESCRIPTION
This PR upgrades the gem to use the newest version of [Bulma 1.0.4](https://github.com/jgthms/bulma/releases/tag/1.0.4). Used the official download from the [Bulma releases page](https://github.com/jgthms/bulma/releases/download/1.0.4/bulma-1.0.4.zip) for these file changes.